### PR TITLE
Update path to .tif files in create-dataset.sh

### DIFF
--- a/create-dataset.sh
+++ b/create-dataset.sh
@@ -12,6 +12,6 @@ cd $OUTDIR
 ../create-tiles.sh ./SRTM_NE_250m_TIF/SRTM_NE_250m.tif 10 10
 ../create-tiles.sh ./SRTM_SE_250m_TIF/SRTM_SE_250m.tif 10 10
 ../create-tiles.sh ./SRTM_W_250m_TIF/SRTM_W_250m.tif 10 20
-rm -rf SRTM_NE_250m.tif SRTM_SE_250m.tif SRTM_W_250m.tif *.rar
+rm -rf SRTM_NE_250m.tif SRTM_SE_250m.tif SRTM_W_250m.tif *.rar *.md
 
 cd $CUR_DIR

--- a/create-dataset.sh
+++ b/create-dataset.sh
@@ -12,7 +12,6 @@ cd $OUTDIR
 ../create-tiles.sh ./SRTM_NE_250m_TIF/SRTM_NE_250m.tif 10 10
 ../create-tiles.sh ./SRTM_SE_250m_TIF/SRTM_SE_250m.tif 10 10
 ../create-tiles.sh ./SRTM_W_250m_TIF/SRTM_W_250m.tif 10 20
-rm -rf SRTM_NE_250m_TIF SRTM_SE_250m_TIF SRTM_W_250m_TIF
 rm -rf SRTM_NE_250m.tif SRTM_SE_250m.tif SRTM_W_250m.tif *.rar
 
 cd $CUR_DIR

--- a/create-dataset.sh
+++ b/create-dataset.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
 OUTDIR="/code/data"
-if [ ! -e $OUTDIR ] ; then
-    echo $OUTDIR does not exist!
-fi
+mkdir -p $OUTDIR
 
 CUR_DIR=$(pwd)
 

--- a/create-dataset.sh
+++ b/create-dataset.sh
@@ -11,9 +11,10 @@ set -eu
 
 cd $OUTDIR
 ../download-srtm-data.sh
-../create-tiles.sh SRTM_NE_250m.tif 10 10
-../create-tiles.sh SRTM_SE_250m.tif 10 10
-../create-tiles.sh SRTM_W_250m.tif 10 20
+../create-tiles.sh ./SRTM_NE_250m_TIF/SRTM_NE_250m.tif 10 10
+../create-tiles.sh ./SRTM_SE_250m_TIF/SRTM_SE_250m.tif 10 10
+../create-tiles.sh ./SRTM_W_250m_TIF/SRTM_W_250m.tif 10 20
+rm -rf SRTM_NE_250m_TIF SRTM_SE_250m_TIF SRTM_W_250m_TIF
 rm -rf SRTM_NE_250m.tif SRTM_SE_250m.tif SRTM_W_250m.tif *.rar
 
 cd $CUR_DIR

--- a/download-srtm-data.sh
+++ b/download-srtm-data.sh
@@ -4,6 +4,6 @@ set -eu
 wget https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_NE_250m_TIF.rar && \
 wget https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_SE_250m_TIF.rar && \
 wget https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_W_250m_TIF.rar && \
-unar -f SRTM_NE_250m_TIF.rar && \
-unar -f SRTM_SE_250m_TIF.rar && \
-unar -f SRTM_W_250m_TIF.rar
+unar -D -f SRTM_NE_250m_TIF.rar && \
+unar -D -f SRTM_SE_250m_TIF.rar && \
+unar -D -f SRTM_W_250m_TIF.rar


### PR DESCRIPTION
This PR updates the path in `create-dataset.sh` to reflect that the result of `wget + unrar` stores the files in a `SRTM_XX_250m_TIF/SRTM_XX_250m.tif` path 