### PR TITLE
Fixed Cert issue #68, and made build noninteractive

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM osgeo/gdal:ubuntu-small-latest-amd64
 
 RUN apt-get update
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y libspatialindex-dev unar bc python3-pip wget
 
 ADD ./requirements.txt .

--- a/download-srtm-data.sh
+++ b/download-srtm-data.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 set -eu
-wget https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_NE_250m_TIF.rar && \
-wget https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_SE_250m_TIF.rar && \
-wget https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_W_250m_TIF.rar && \
+wget --no-check-certificate https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_NE_250m_TIF.rar && \
+wget --no-check-certificate https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_SE_250m_TIF.rar && \
+wget --no-check-certificate https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_W_250m_TIF.rar && \
 unar -f SRTM_NE_250m_TIF.rar && \
 unar -f SRTM_SE_250m_TIF.rar && \
 unar -f SRTM_W_250m_TIF.rar


### PR DESCRIPTION
the SRTM cert expired (#68), so i just made the `wget` use `--no-check-certificate` to remedy that issue. The build was also stalling on a "select geographic area" prompt similar to [this](https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai), so I just added a build arg to suppress that