### PR TITLE
Update to create-dataset.sh

### DIFF
--- a/create-dataset.sh
+++ b/create-dataset.sh
@@ -11,6 +11,9 @@ set -eu
 
 cd $OUTDIR
 ../download-srtm-data.sh
+mv ./SRTM_NE_250m_TIF/SRTM_NE_250m.tif SRTM_NE_250m.tif
+mv ./SRTM_SE_250m_TIF/SRTM_SE_250m.tif SRTM_SE_250m.tif
+mv ./SRTM_W_250m_TIF/SRTM_W_250m.tif SRTM_W_250m.tif
 ../create-tiles.sh SRTM_NE_250m.tif 10 10
 ../create-tiles.sh SRTM_SE_250m.tif 10 10
 ../create-tiles.sh SRTM_W_250m.tif 10 20


### PR DESCRIPTION
Without these changes, an error is thrown showing that the tif files cannot be accessed. This is because extracting the files from the .rar file puts them in their own folder/directory inside of the data folder and the script doesn't expect that. This change moves the files where they need to be for the script to function properly and complete without error.

Beware that it's possible this may be a case by case scenario. Perhaps on some systems the .rar files are extracted as expected while on others it is not.