### PR TITLE
Dockerfile fixes, download script update and req update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,11 @@
 FROM osgeo/gdal:ubuntu-small-latest-amd64
 
+ENV TZ=Europe/Madrid
+ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
+ENV CINCLUDE_PATH=/usr/include/gdal
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update
-RUN apt-get install -y libspatialindex-dev unar bc python3-pip wget
+RUN apt-get install -y libspatialindex-dev unar bc python3-pip wget libgdal-dev gdal-bin
 
 ADD ./requirements.txt .
 RUN pip install -r requirements.txt

--- a/download-srtm-data.sh
+++ b/download-srtm-data.sh
@@ -7,3 +7,6 @@ wget https://srtm.csi.cgiar.org/wp-content/uploads/files/250m/SRTM_W_250m_TIF.ra
 unar -f SRTM_NE_250m_TIF.rar && \
 unar -f SRTM_SE_250m_TIF.rar && \
 unar -f SRTM_W_250m_TIF.rar
+mv SRTM_NE_250m_TIF/SRTM_NE_250m.tif .
+mv SRTM_SE_250m_TIF/SRTM_SE_250m.tif .
+mv SRTM_W_250m_TIF/SRTM_W_250m.tif .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-lazy==1.4
-GDAL==3.3.1
 bottle==0.12.19
-rtree==0.8.3
+GDAL==3.7.0
 gunicorn==20.1.0
+lazy==1.4
+numpy==1.21.5
+Pillow==9.0.1
+Rtree==0.8.3


### PR DESCRIPTION
Dockerfile updated fixing gdal dependences and avoiding TZdata install problems with timezone
Updated pip requeriments to fix "no module named _gdal_array" 
And download-srtm-data script now moves all tif archives to data folder becose unar makes one folder for every rar